### PR TITLE
Add bob-walker in Scala

### DIFF
--- a/bob-walker.scala
+++ b/bob-walker.scala
@@ -1,0 +1,50 @@
+final case object bobwalker {
+
+  def main(args: Array[String]) {
+    val bob_modes = process(args)
+    start_bob(bob_modes)
+  }
+
+  def process(args: Array[String]): Array[String] = {
+    val all_args: Array[Char] = args.flatMap(x => x)
+    val bob_modes = for {
+      x <- all_args
+    } yield add_mode(x)
+    bob_modes.flatMap(x => x)
+  }
+
+  def add_mode(letter: Char): Array[String] = {
+    var new_modes: Array[String] = Array[String]("beard", "beer", "pie")
+    letter match {
+      case 'd' =>
+        println("Drunk mode not yet enabled")
+      case 'p' =>
+        new_modes = new_modes :+ "chef"
+        new_modes = new_modes :+ "perl"
+        new_modes = new_modes :+ "CPAN"
+      case 's' => 
+        new_modes = new_modes :+ "rugby"
+        new_modes = new_modes :+ "cricket"
+      case 'x' =>
+        new_modes = new_modes :+ "mince pies"
+        new_modes = new_modes :+ "reindeer"
+      case _   => //do nothing
+    }
+    new_modes
+  }
+
+  def start_bob(bob_modes: Array[String]) = {
+    var i = 0
+    while (i < 1000000000) {
+      print_bob(bob_modes)
+      i = i + 1
+    }
+  }
+
+  def print_bob(bob_modes: Array[String]) = {
+    for {
+      x <- bob_modes
+    } println(x)
+  }
+
+}


### PR DESCRIPTION
Had to be done, of course. It's not fully featured (no random, no drunk), and there are a number of improvements to the code to be made, but it's a start.

To test:

`scala bob-walker.scala -s`

I've just realised that it doesn't work without _any_ command-line arguments, but it's too late at night now for me to fix that. It accepts command-line args either separately ('-d -s -x' etc) or together ('-dxs') and also the `-` is ignored, so:

`scala bob-walker.scala dsxp` for full glory. `^C` to stop, or it will stop eventually.
