### PR TITLE
Implement bob in bc(1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ awk -f bob-walker.awk [-v sport=true]
 ./bob-walker.sh
 ```
 
+### bc
+
+```sh
+bc bob-walker.bc
+```
+
 ### Bootloader
 
 ```

--- a/bob-walker.bc
+++ b/bob-walker.bc
@@ -1,0 +1,6 @@
+/* bob walker implemented in bc(1) */
+while (1) {
+  print "beer\n"
+  print "beard\n"
+  print "pie\n"
+}

--- a/bob-walker.bc
+++ b/bob-walker.bc
@@ -2,9 +2,9 @@
 
 print "\n"
 print "When prompted, enter 0 (no) or 1 (yes) to answer.\n\n"
+print "Enable programming mode? "; dev_mode = read()
 print "Enable sport mode? "; sport_mode = read()
 print "Enable Christmas mode? "; xmas_mode = read()
-print "Enable programming mode? "; dev_mode = read()
 
 while (1) {
   print "beer\n"

--- a/bob-walker.bc
+++ b/bob-walker.bc
@@ -3,6 +3,7 @@
 print "\n"
 print "When prompted, enter 0 (no) or 1 (yes) to answer.\n\n"
 print "Enable sport mode? "; sport_mode = read()
+print "Enable Christmas mode? "; xmas_mode = read()
 
 while (1) {
   print "beer\n"
@@ -14,5 +15,11 @@ while (1) {
     print "cricket\n"
     print "rugby\n"
     print "tug of war\n"
+  }
+
+  if (xmas_mode > 0)
+  {
+    print "reindeer\n"
+    print "mince pies\n"
   }
 }

--- a/bob-walker.bc
+++ b/bob-walker.bc
@@ -4,11 +4,19 @@ print "\n"
 print "When prompted, enter 0 (no) or 1 (yes) to answer.\n\n"
 print "Enable sport mode? "; sport_mode = read()
 print "Enable Christmas mode? "; xmas_mode = read()
+print "Enable programming mode? "; dev_mode = read()
 
 while (1) {
   print "beer\n"
   print "beard\n"
   print "pie\n"
+
+  if (dev_mode > 0)
+  {
+    print "chef\n"
+    print "CPAN\n"
+    print "perl\n"
+  }
 
   if (sport_mode > 0)
   {

--- a/bob-walker.bc
+++ b/bob-walker.bc
@@ -1,6 +1,18 @@
 /* bob walker implemented in bc(1) */
+
+print "\n"
+print "When prompted, enter 0 (no) or 1 (yes) to answer.\n\n"
+print "Enable sport mode? "; sport_mode = read()
+
 while (1) {
   print "beer\n"
   print "beard\n"
   print "pie\n"
+
+  if (sport_mode > 0)
+  {
+    print "cricket\n"
+    print "rugby\n"
+    print "tug of war\n"
+  }
 }


### PR DESCRIPTION
An implementation of bob walker in GNU `[bc](1)`.

Supports sport, Christmas and programming modes.

I tried implementing drunk mode by printing the words using base-36 numerals (which includes the full Latin alphabet) and manipulating the numbers to produce slurred words, alas `bc` does not support bases larger than 16 for input [1].

`bc` also does not an array of strings, which would have allowed me to convert bc's base-10 representation of base-36 numbers [2] into Latin characters (as seen in [this Bash example](http://en.wikipedia.org/wiki/Base_36#bash_implementation)).

[bc]: http://en.wikipedia.org/wiki/Bc_(programming_language)
[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=263071
[2]: https://www.gnu.org/software/bc/manual/html_mono/bc.html#SEC15